### PR TITLE
Fix IndexError when using batch of prompts and batch of images

### DIFF
--- a/promptcap/modeling_ofa.py
+++ b/promptcap/modeling_ofa.py
@@ -1188,7 +1188,7 @@ class OFAEncoder(OFAPreTrainedModel):
         if patch_images is not None:
             image_embed, image_num_patches, image_padding_mask, image_position_ids, image_pos_embed = \
                 self.get_patch_images_info(patch_images, sample_patch_num, input_ids.device)
-            image_padding_mask[~patch_masks] = True
+            # image_padding_mask[~patch_masks] = True # comment the line to temporarily fix the bug of mismatch
         if patch_images_2 is not None:
             image_embed_2, image_num_patches_2, image_padding_mask_2, image_position_ids_2, image_pos_embed_2 = \
                 self.get_patch_images_info(patch_images_2, sample_patch_num, input_ids.device)


### PR DESCRIPTION
Currently passing a batch of prompts and a batch of images raises an Index error in OFA.

This was raised upstream in [#226](https://github.com/OFA-Sys/OFA/issues/226)  and fixed in [this commit](https://github.com/OFA-Sys/OFA/commit/1f70b58b9d5d08e7d4285c303e12c88f7a3998bb).

This PR just carries out the same fix here.

Testing:
commenting out the line to match upstream generates batches of captions from OFA with no IndexError, as expected